### PR TITLE
Fixes for `pauli_operations.py`

### DIFF
--- a/src/psp/pauli_operations.py
+++ b/src/psp/pauli_operations.py
@@ -1,6 +1,5 @@
 # Python version 3.11.5
 # Modified on December 18, 2023
-
 """
 Pauli Operations
 ----------------
@@ -15,9 +14,7 @@ import numpy as np
 
 # These arrays are used to find products of Pauli matrices
 RULES = np.array([1, 3, 1, 3])
-SIGN_RULES = np.array([[1, 1, 1, 1],
-                       [1, 1, 1j, -1j],
-                       [1, -1j, 1, 1j],
+SIGN_RULES = np.array([[1, 1, 1, 1], [1, 1, 1j, -1j], [1, -1j, 1, 1j],
                        [1, 1j, -1j, 1]])
 
 
@@ -41,7 +38,7 @@ def product(sigma1: int, sigma2: int) -> int:
 
 
 def signed_product(sigma1: int, sigma2: int) -> tuple[int, complex]:
-    """
+    r"""
     Finds the signed product of two Pauli matrices.
 
     Parameters:
@@ -62,34 +59,39 @@ def signed_product(sigma1: int, sigma2: int) -> tuple[int, complex]:
     return product(sigma1, sigma2), complex(SIGN_RULES[sigma1, sigma2])
 
 
-def string_product(string1: tuple[int], string2: tuple[int]) -> tuple[tuple[int], complex, bool]:
+def string_product(
+        string1: tuple[int, ...],
+        string2: tuple[int, ...]) -> tuple[tuple[int, ...], complex, bool]:
     """
     Returns the signed product of two Pauli strings and whether they commute.
 
     Parameters:
     -----------
-    string1: tuple[int]
+    string1: tuple[int, ...]
         The first Pauli string.
-    string2: tuple[int]
+    string2: tuple[int, ...]
         The second Pauli string.
 
     Returns:
     --------
-        result: tuple[int]
-            The product of the two strings.
-        sign: complex
-            The sign of the product.
-        commutator: bool
-           True if the two strings commute and False otherwise.
+    result: tuple[int, ...]
+        The product of the two strings.
+    sign: complex
+        The sign of the product.
+    commutator: bool
+       True if the two strings commute and False otherwise.
     """
     # Consistency check
     if len(string1) != len(string2):
-        raise Exception(f"Dimension mismatch ({len(string1)} and {len(string2)})")
+        raise Exception(
+            f"Dimension mismatch ({len(string1)} and {len(string2)})")
 
     string1_array = np.array(string1)
     string2_array = np.array(string2)
-    sign = np.prod(SIGN_RULES[string1_array, string2_array])
-    result = tuple((string1_array + np.multiply(string2_array, RULES[string1_array])) % 4)
+    sign: complex = np.prod(SIGN_RULES[string1_array,
+                                       string2_array])  # type: ignore
+    result: tuple[int, ...] = tuple(
+        (string1_array + np.multiply(string2_array, RULES[string1_array])) % 4)
 
     if sign.imag == 0:
         return result, sign, True
@@ -108,22 +110,24 @@ def string_product(string1: tuple[int], string2: tuple[int]) -> tuple[tuple[int]
 #     return numbers
 
 
-def strings_to_dict(strings: list[tuple[int]] | tuple[int], coefficients: list[complex] | complex) -> dict[
-    tuple[int], complex]:
+def strings_to_dict(
+        strings: list[tuple[int, ...]] | tuple[int, ...],
+        coefficients: list[complex] | complex
+) -> dict[tuple[int, ...], complex]:
     """
     Returns a dictionary for a Pauli sentence with the Pauli strings as keys and their corresponding coefficients as
     values.
 
     Parameters:
     -----------
-    strings: list[tuple[int]] or tuple[int]:
+    strings: list[tuple[int, ...]] | tuple[int, ...]:
         Can take one Pauli string or a list of Pauli strings.
     coefficients: list[complex] or complex:
         Can take one coefficient or a list of coefficients.
 
     Returns:
     --------
-    dict[tuple[int], complex]:
+    dict[tuple[int, ...], complex]:
         The Pauli sentence as a dictionary.
     """
     # Data reformatting
@@ -133,22 +137,25 @@ def strings_to_dict(strings: list[tuple[int]] | tuple[int], coefficients: list[c
         strings_array = np.squeeze(strings_array, axis=0)
     # Consistency check
     if len(strings_array) != len(coefficients_array):
-        raise Exception(f"Length mismatch - strings: {len(strings_array)}, coefficients: {len(coefficients_array)}")
+        raise Exception(
+            f"Length mismatch - strings: {len(strings_array)}, coefficients: {len(coefficients_array)}"
+        )
 
-    strings_array = tuple(map(tuple, strings_array))
-    return dict(zip(strings_array, coefficients_array))
+    strings_tuple = tuple(map(tuple, strings_array))
+    return dict(zip(strings_tuple, coefficients_array))
 
 
-def full_sum(sentence1: dict[tuple[int], complex], sentence2: dict[tuple[int], complex], tol: float = 0) -> dict[
-    tuple[int], complex]:
+def full_sum(sentence1: dict[tuple[int, ...], complex],
+             sentence2: dict[tuple[int, ...], complex],
+             tol: float = 0) -> dict[tuple[int, ...], complex]:
     """
     Finds the sum of two Pauli sentences.
 
     Parameters:
     -----------
-    sentence1: dict[tuple[int], complex]
+    sentence1: dict[tuple[int, ...], complex]
         The first Pauli sentence.
-    sentence2: dict[tuple[int], complex]
+    sentence2: dict[tuple[int, ...], complex]
         The second Pauli sentence.
     tol: float
         Tolerance. Non-negative number. Any value less than or equal to the tolerance is considered 0. Default tolerance
@@ -156,7 +163,7 @@ def full_sum(sentence1: dict[tuple[int], complex], sentence2: dict[tuple[int], c
 
     Returns:
     --------
-    result: dict[tuple[int], complex]
+    result: dict[tuple[int, ...], complex]
         The sum of the two Pauli sentences as a dictionary.
     """
     result = sentence1.copy()
@@ -168,16 +175,17 @@ def full_sum(sentence1: dict[tuple[int], complex], sentence2: dict[tuple[int], c
     return result
 
 
-def full_product(sentence1: dict[tuple[int], complex], sentence2: dict[tuple[int], complex], tol: float = 0) -> \
-        dict[tuple[int], complex]:
+def full_product(sentence1: dict[tuple[int, ...], complex],
+                 sentence2: dict[tuple[int, ...], complex],
+                 tol: float = 0) -> dict[tuple[int, ...], complex]:
     """
     Finds the product of two Pauli sentences.
 
     Parameters:
     -----------
-    sentence1: dict[tuple[int], complex]
+    sentence1: dict[tuple[int, ...], complex]
         The first Pauli sentence.
-    sentence2: dict[tuple[int], complex]
+    sentence2: dict[tuple[int, ...], complex]
         The second Pauli sentence.
     tol: float
         Tolerance. Non-negative number. Any value less than or equal to the tolerance is considered 0. Default tolerance
@@ -185,57 +193,61 @@ def full_product(sentence1: dict[tuple[int], complex], sentence2: dict[tuple[int
 
     Returns:
     --------
-    result: dict[tuple[int], complex]
+    result: dict[tuple[int, ...], complex]
         The product of the two Pauli sentences as a dictionary.
     """
-    result = {}
+    result: dict[tuple[int, ...], complex] = {}
     for key1 in sentence1.keys():
         for key2 in sentence2.keys():
             string, sign, c = string_product(key1, key2)
-            result[string] = result.get(string, 0) + sign * sentence1[key1] * sentence2[key2]
+            result[string] = result.get(
+                string, 0) + sign * sentence1[key1] * sentence2[key2]
             if abs(result[string]) <= tol:
                 result.pop(string)
 
     return result
 
 
-def string_exp(string: tuple[int], angle: float) -> dict[tuple[int], complex]:
-    """
+def string_exp(string: tuple[int, ...],
+               angle: float) -> dict[tuple[int, ...], complex]:
+    r"""
     Finds the exponential of a Pauli string :math:`\mathrm{e}^{\mathrm{i} x P} = \cos{x} + \mathrm{i}P\sin{x}`.
 
     Parameters:
     -----------
-    string: tuple[int]
+    string: tuple[int, ...]
         The Pauli string to be exponentiated.
     angle: float
         The angle of rotation.
 
     Returns:
     --------
-    result: dict[tuple[int], complex]
+    result: dict[tuple[int, ...], complex]
         The resulting Pauli sentence as a dictionary.
     """
     result = {}
     if np.cos(angle) != 0:
-        result[(0,) * len(string)] = np.cos(angle)
+        result[(0, ) * len(string)] = np.cos(angle)
     if np.sin(angle) != 0:
         result[string] = 1j * np.sin(angle)
     return result
 
 
-def exp_conjugation(generators: list[tuple[int]] | tuple[int], angles: list[float] | float,
-                    sentence: dict[tuple[int], complex], tol: float = 0) -> dict[tuple[int], complex]:
-    """
+def exp_conjugation(generators: list[tuple[int, ...]] | tuple[int, ...],
+                    angles: list[float] | float,
+                    sentence: dict[tuple[int, ...], complex],
+                    tol: float = 0) -> dict[tuple[int, ...], complex]:
+    r"""
     Returns the conjugation of a Pauli sentence :math:`\mathrm{e}^{\mathrm{i} x_{1} P_1} ...
     \mathrm{e}^{\mathrm{i} x_n P_n} X \mathrm{e}^{-\mathrm{i} x_{n} P_n} ... \mathrm{e}^{-\mathrm{i} x_1 P_1}`.
     
     Parameters:
     -----------
-    generators: list[tuple[int]] | tuple[int]
+    generators: list[tuple[int, ...]] | tuple[int, ...]
         Can take a one Pauli string or a list of Pauli strings to be exponentiated.
     angles: list[float] | float
         Can take one angle or a list of angles.
-    sentence: dict[tuple[int], complex]
+    sentence: dict[tuple[int, ...], complex]
         The Pauli sentence to be conjugated.
     tol: float
         Tolerance. Non-negative number. Any value less than or equal to the tolerance is considered 0. Default tolerance
@@ -243,7 +255,7 @@ def exp_conjugation(generators: list[tuple[int]] | tuple[int], angles: list[floa
 
     Returns:
     --------
-    result: dict[tuple[int], complex]
+    result: dict[tuple[int, ...], complex]
         The resulting Pauli sentence as a dictionary.
     """
     # Data reformatting
@@ -256,21 +268,25 @@ def exp_conjugation(generators: list[tuple[int]] | tuple[int], angles: list[floa
 
     # Consistency check
     if len(generators_array) != len(angles_array):
-        raise Exception(f"Length mismatch - generators: {len(generators_array)}, angles: {len(angles_array)}")
+        raise Exception(
+            f"Length mismatch - generators: {len(generators_array)}, angles: {len(angles_array)}"
+        )
 
     result = sentence.copy()
     for i in range(len(angles_array) - 1, -1, -1):
-        temp = {}
+        temp: dict[tuple[int, ...], complex] = {}
         for key in result:
             coefficient = temp[key]
-            string, sign, c = string_product(tuple(generators_array[i]), key)  # type: ignore
+            string, sign, c = string_product(tuple(generators_array[i]),
+                                             key)  # type: ignore
             # If the ith exponent commutes with string (key) in the Pauli sentence do nothing
             if c:
                 temp[key] = temp.get(key, 0) + coefficient
             # If it doesn't commute it necessary anticommutes. Perform the operation exp(2ixP).string
             else:
                 temp[key] = temp.get(key, 0) + cosine_array[i] * coefficient
-                temp[string] = temp.get(string, 0) + sign * 1j * sine_array[i] * coefficient
+                temp[string] = temp.get(
+                    string, 0) + sign * 1j * sine_array[i] * coefficient
 
                 if abs(temp[string]) <= tol:
                     temp.pop(string)
@@ -282,13 +298,13 @@ def exp_conjugation(generators: list[tuple[int]] | tuple[int], angles: list[floa
     return result
 
 
-def trace(sentence: dict[tuple[int], complex]) -> float | complex:
+def trace(sentence: dict[tuple[int, ...], complex]) -> float | complex:
     """
     Finds the normalized trace of a Pauli sentence.
     
     Parameters:
     -----------
-    sentence: dict[tuple[int], complex]
+    sentence: dict[tuple[int, ...], complex]
         The Pauli sentence.
 
     Returns:
@@ -296,5 +312,5 @@ def trace(sentence: dict[tuple[int], complex]) -> float | complex:
     trace: float | complex
         The trace of the Pauli sentence divided by the length of a Pauli string.
     """
-    identity = (0,) * len(next(iter(sentence)))
+    identity = (0, ) * len(next(iter(sentence)))
     return sentence.get(identity, 0)


### PR DESCRIPTION
Made some fixes to the type annotations to appease `mypy` and applied some
documentation and type annotation fixes for clarity. I highly recommend
checking out the `git diff` to see all the changes and approve them.

Some things of note:
- Remember, a `tuple` with all elements of one type with indefinitely many
  elements is notated as follows: `tuple[<type>, ...]`.

- Also, I fixed some documentation errors, in particular the math embedding in
  docstrings. Remember that in Python a backslash symbol signifies an escape
  character. Since it's unlikely that you will ever really be intending to have
  any escape characters, it may be preferable to make all of your docstrings
  what are called "raw strings".

```python
"This is a regular string, and \n gives us a newline."
r"This is a raw string, and \n gives us a 'backslash-n'."
```
