### PR TITLE
Update Dependencies, Fix Imports, Move `coo_array` to `bsr_array`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,8 @@ authors = [
 dependencies = [
     "numpy",
     "scipy",
+    "openfermion",
+    "qiskit",
 ]
 
 [project.optional-dependencies]
@@ -28,4 +30,8 @@ build-backend = "setuptools.build_meta"
 
 [[tool.mypy.overrides]]
 module = "scipy.*"
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = "qiskit.*"
 ignore_missing_imports = true

--- a/src/sumaq/hamiltonian/built_in.py
+++ b/src/sumaq/hamiltonian/built_in.py
@@ -50,12 +50,12 @@ class Fermi_Hubbard(Operator):
         """
         return self
 
-    def as_spmatrix(self) -> NDArray:
+    def as_spmatrix(self) -> bsr_array:
         """
         This method returns the operator as a sparse matrix.
 
         Returns:
-            coo_array : The operator as a sparse matrix.
+            bsr_array : The operator as a sparse matrix.
         """
         sp_fermi_hubbard = get_sparse_from_paulis(
             *generate_paulis_from_fermionic_ops(self.fermi_hubbard_dict, self.N_sites)

--- a/src/sumaq/hamiltonian/built_in.py
+++ b/src/sumaq/hamiltonian/built_in.py
@@ -1,5 +1,5 @@
-from operators import *
-from helper_functions import *
+from .operators import *
+from ..helper_functions import *
 
 # There's a lot of things we need to finish before these classes are ready to go. But hopefully this is a good start.
 

--- a/src/sumaq/hamiltonian/operators.py
+++ b/src/sumaq/hamiltonian/operators.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from abc import abstractmethod, ABC
 
 from numpy.typing import NDArray
-from scipy.sparse import coo_array
+from scipy.sparse import bsr_array
 
 from ..pauli import PauliSentence
 from ..fermionic import FermionicSentence
@@ -29,7 +29,7 @@ class Operator(ABC):
         return self.as_spmatrix().todense()
 
     @abstractmethod
-    def as_spmatrix(self) -> coo_array:
+    def as_spmatrix(self) -> bsr_array:
         ...
 
     @abstractmethod

--- a/tests/test_helper_functions.py
+++ b/tests/test_helper_functions.py
@@ -50,14 +50,15 @@ def test_generate_paulis_from_fermionic_ops():
 def test_get_sparse_from_paulis():
     test_coeffs = np.array([1.0, 2.0, 1.0, -3.0])
     test_paulis = ["-X", "Y-", "XX", "YY"]
-    expected_sparse_matrix = np.array(
-        [
+    expected_sparse_matrix = bsr_array(
+        np.array([
             [0.0 + 0.0j, 1.0 + 0.0j, 0.0 - 2.0j, 4.0 + 0.0j],
             [1.0 + 0.0j, 0.0 + 0.0j, -2.0 + 0.0j, 0.0 - 2.0j],
             [0.0 + 2.0j, -2.0 + 0.0j, 0.0 + 0.0j, 1.0 + 0.0j],
             [4.0 + 0.0j, 0.0 + 2.0j, 1.0 + 0.0j, 0.0 + 0.0j],
-        ]
-    )
-    assert np.allclose(
-        get_sparse_from_paulis(test_coeffs, test_paulis), expected_sparse_matrix
-    )
+        ]))
+
+    print(get_sparse_from_paulis(test_coeffs, test_paulis) - expected_sparse_matrix)
+    assert bsr_allclose(get_sparse_from_paulis(test_coeffs, test_paulis),
+                        expected_sparse_matrix)
+


### PR DESCRIPTION
- **Added necessary project dependencies.**

The `openfermion` and `qiskit` dependencies have been added to `pyproject.toml`. A `mypy` error fix for `qiskit` types has also been added to `pyproject.toml`

- **Swapped COO sparse arrays with BSR sparse arrays and changed sparse output types to reflect the underlying sparse arrays.**

Previously the sparse output types were denoted as `NDArray` even when theywere other types (e.g. `coo_array`). Now the types are denoted with the true types returned (and accepted) by functions. Additionally, `coo_array` was replaced with `bsr_array` for the purpose of allowing easy arithmetic operations with minimal user effort. Finally, the `bsr_allclose` method was made as a helper function so that `np.allclose` is not used outside of its scope, for example, when working with sparse matrices.

- **Fixed imports by changing imports to be appropriate relative imports**

Note for future reference: When working with packages and modules, imports should be given in "relative" form. The change made was as follows:

```diff
--- a/src/sumaq/hamiltonian/built_in.py
+++ b/src/sumaq/hamiltonian/built_in.py
@@ -1,5 +1,5 @@
-from operators import *
-from helper_functions import *
+from .operators import *
+from ..helper_functions import *
```
Here, `operators` was replaced with `.operators` because it is a module that has the same parent module. On the other hand, `helper_functions` was replaced with `..helper_functions` because `helper_functions` is a child of the "grandparent" module.
